### PR TITLE
fix: Restructure init() methods

### DIFF
--- a/ros/src/tl_detector/light_classification/tl_classifier.py
+++ b/ros/src/tl_detector/light_classification/tl_classifier.py
@@ -18,7 +18,6 @@ class TLClassifier(object):
         self.bridge = CvBridge()
         '''
 
-
         if is_simulation:
             self.MODEL_NAME = 'light_classification/frozen-ssd_inception-simulation'
         else:

--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -45,14 +45,7 @@ class DBWNode(object):
         steer_ratio = rospy.get_param('~steer_ratio', 14.8)
         max_lat_accel = rospy.get_param('~max_lat_accel', 3.)
         max_steer_angle = rospy.get_param('~max_steer_angle', 8.)
-
-        self.steer_pub = rospy.Publisher('/vehicle/steering_cmd',
-                                         SteeringCmd, queue_size=1)
-        self.throttle_pub = rospy.Publisher('/vehicle/throttle_cmd',
-                                            ThrottleCmd, queue_size=1)
-        self.brake_pub = rospy.Publisher('/vehicle/brake_cmd',
-                                         BrakeCmd, queue_size=1)
-
+                
         # TODO: Create `Controller` object
         self.controller = Controller(vehicle_mass=vehicle_mass,
                                      fuel_capacity=fuel_capacity,
@@ -65,19 +58,27 @@ class DBWNode(object):
                                      max_lat_accel=max_lat_accel,
                                      max_steer_angle=max_steer_angle)
 
-        # TODO: Subscribe to all the topics you need to
-        rospy.Subscriber('/vehicle/dbw_enabled', Bool, self.dbw_enabled_cb)
-        rospy.Subscriber('/twist_cmd', TwistStamped, self.twist_cb)
-        rospy.Subscriber('/current_velocity', TwistStamped, self.velocity_cb)
-        
         self.current_vel = None
         self.curr_ang_vel = None
         self.dbw_enabled = None
         self.linear_vel = None
         self.angular_vel = None
         self.throttle = self.steering = self.brake = 0
+
+        self.steer_pub = rospy.Publisher('/vehicle/steering_cmd',
+                                         SteeringCmd, queue_size=1)
+        self.throttle_pub = rospy.Publisher('/vehicle/throttle_cmd',
+                                            ThrottleCmd, queue_size=1)
+        self.brake_pub = rospy.Publisher('/vehicle/brake_cmd',
+                                         BrakeCmd, queue_size=1)
+
+        # TODO: Subscribe to all the topics you need to
+        rospy.Subscriber('/vehicle/dbw_enabled', Bool, self.dbw_enabled_cb)
+        rospy.Subscriber('/twist_cmd', TwistStamped, self.twist_cb)
+        rospy.Subscriber('/current_velocity', TwistStamped, self.velocity_cb)
         
         self.loop()
+
 
     def loop(self):
         rate = rospy.Rate(50) # 50Hz
@@ -95,15 +96,19 @@ class DBWNode(object):
             
             rate.sleep()
 
+
     def dbw_enabled_cb(self, msg):
         self.dbw_enabled = msg
-        
+
+
     def twist_cb(self, msg):
         self.linear_vel = msg.twist.linear.x
         self.angular_vel = msg.twist.angular.z
-        
+
+
     def velocity_cb(self, msg):
         self.current_vel = msg.twist.linear.x
+
             
     def publish(self, throttle, brake, steer):
         tcmd = ThrottleCmd()

--- a/ros/src/waypoint_loader/waypoint_loader.py
+++ b/ros/src/waypoint_loader/waypoint_loader.py
@@ -18,12 +18,13 @@ MAX_DECEL = 1.0
 class WaypointLoader(object):
 
     def __init__(self):
-        rospy.init_node('waypoint_loader', log_level=rospy.DEBUG)
+        rospy.init_node('waypoint_loader', log_level=rospy.DEBUG)        
 
         self.pub = rospy.Publisher('/base_waypoints', Lane, queue_size=1, latch=True)
 
         self.velocity = self.kmph2mps(rospy.get_param('~velocity'))
         self.new_waypoint_loader(rospy.get_param('~path'))
+
         rospy.spin()
 
     def new_waypoint_loader(self, path):

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -28,23 +28,23 @@ MAX_DECEL = 2.5 # m/s - Maximum deceleration rate to keep jerk below 10m/s^3
 
 class WaypointUpdater(object):
     def __init__(self):        
-        rospy.init_node('waypoint_updater')
-
-        rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
-        rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)     
-        rospy.Subscriber('/traffic_waypoint', Int32, self.traffic_cb)
-        
-        # **** Figure out what this datatype is. Do we need to create this message? ****
-        #rospy.Subscriber('/obstacle_waypoint', ?, self.obstacle_cb) 
-
-        self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, queue_size=1)
+        rospy.init_node('waypoint_updater')        
 
         # TODO: Add other member variables you need below
         self.base_lane = None
         self.pose = None
         self.stopline_wp_idx = -1
         self.waypoints_2d = None
-        self.waypoint_tree = None        
+        self.waypoint_tree = None
+
+        self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, queue_size=1)    
+
+        rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
+        rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)     
+        rospy.Subscriber('/traffic_waypoint', Int32, self.traffic_cb)
+        
+        # **** Figure out what this datatype is. Do we need to create this message? ****
+        #rospy.Subscriber('/obstacle_waypoint', ?, self.obstacle_cb)          
         
         self.loop()
 


### PR DESCRIPTION
Restructured subscriber and instance variable layout of init() methods
to prevent function callbacks from occurring before the instance variables
are all initialized.