### PR TITLE
feat: Add variable displacement threshold

### DIFF
--- a/ros/src/tl_detector/light_classification/tl_classifier.py
+++ b/ros/src/tl_detector/light_classification/tl_classifier.py
@@ -94,14 +94,14 @@ class TLClassifier(object):
             end_classification_t = datetime.datetime.now()
             elapsed_time = end_classification_t - start_classification_t
 
-            print("Classification took:", elapsed_time.total_seconds())
+            #print("Classification took:", elapsed_time.total_seconds())
 
         boxes = np.squeeze(boxes)
         scores = np.squeeze(scores)
         classes = np.squeeze(classes).astype(np.int32)
 
         #print('Best class: ', classes[0])
-        print('Best score: ', scores[0])
+        #print('Best score: ', scores[0])
 
         if scores[0] > self.threshold:
             if classes[0] == 1:

--- a/ros/src/waypoint_follower/include/pure_pursuit_core.h
+++ b/ros/src/waypoint_follower/include/pure_pursuit_core.h
@@ -38,6 +38,7 @@
 // C++ includes
 #include <memory>
 #include "libwaypoint_follower.h"
+#include "std_msgs/Bool.h"
 
 enum class Mode
 {
@@ -87,6 +88,8 @@ private:
   void getNextWaypoint();
   geometry_msgs::TwistStamped outputZero() const;
   geometry_msgs::TwistStamped outputTwist(geometry_msgs::Twist t) const;
+  
+  //styx_msgs::DisplacementThreshold PurePursuit::outputDisplacementThreshold() const;
 
 public:
   PurePursuit(bool linear_interpolate_mode)
@@ -98,7 +101,7 @@ public:
     , initial_velocity_(5.0)
     , lookahead_distance_calc_ratio_(2.0)
     , minimum_lookahead_distance_(6.0)
-    , displacement_threshold_(0.05)
+    , displacement_threshold_(0.2)
     , relative_angle_threshold_(5.)
     , waypoint_set_(false)
     , pose_set_(false)
@@ -115,6 +118,7 @@ public:
   void callbackFromCurrentPose(const geometry_msgs::PoseStampedConstPtr &msg);
   void callbackFromCurrentVelocity(const geometry_msgs::TwistStampedConstPtr &msg);
   void callbackFromWayPoints(const styx_msgs::LaneConstPtr &msg);
+  void callbackFromSimulationStatus(const std_msgs::Bool::ConstPtr &msg);
 
   // for debug
   geometry_msgs::Point getPoseOfNextWaypoint() const
@@ -136,6 +140,7 @@ public:
   }
   // processing for ROS
   geometry_msgs::TwistStamped go();
+  double getDisplacementThreshold();
 };
 }
 

--- a/ros/src/waypoint_follower/src/pure_pursuit.cpp
+++ b/ros/src/waypoint_follower/src/pure_pursuit.cpp
@@ -29,6 +29,9 @@
 */
 
 #include "pure_pursuit_core.h"
+#include <iostream>
+#include "std_msgs/String.h"
+#include "std_msgs/Float64.h"
 
 constexpr int LOOP_RATE = 30; //processing frequency
 
@@ -52,6 +55,7 @@ int main(int argc, char **argv)
   ROS_INFO("set publisher...");
   // publish topic
   ros::Publisher cmd_velocity_publisher = nh.advertise<geometry_msgs::TwistStamped>("twist_cmd", 10);
+  ros::Publisher displacement_thresh_pub = nh.advertise<std_msgs::Float64>("displacement_threshold", 1);
 
   ROS_INFO("set subscriber...");
   // subscribe topic
@@ -61,6 +65,8 @@ int main(int argc, char **argv)
       nh.subscribe("current_pose", 10, &waypoint_follower::PurePursuit::callbackFromCurrentPose, &pp);
   ros::Subscriber est_twist_subscriber =
       nh.subscribe("current_velocity", 10, &waypoint_follower::PurePursuit::callbackFromCurrentVelocity, &pp);
+  ros::Subscriber sim_status_subscriber = 
+      nh.subscribe("simulation_status", 10, &waypoint_follower::PurePursuit::callbackFromSimulationStatus, &pp);
 
   ROS_INFO("pure pursuit start");
   ros::Rate loop_rate(LOOP_RATE);
@@ -68,6 +74,16 @@ int main(int argc, char **argv)
   {
     ros::spinOnce();
     cmd_velocity_publisher.publish(pp.go());
+
+    // Publish Displacement Threshold
+    std_msgs::Float64 msg;
+    //std::stringstream ss;
+    //ss << pp.getDisplacementThreshold();
+    //msg.data = ss.str();
+    msg.data = pp.getDisplacementThreshold();
+
+    displacement_thresh_pub.publish(msg);
+
     loop_rate.sleep();
   }
 

--- a/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
+++ b/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
@@ -54,6 +54,19 @@ void PurePursuit::callbackFromWayPoints(const styx_msgs::LaneConstPtr &msg)
   // ROS_INFO_STREAM("waypoint subscribed");
 }
 
+void PurePursuit::callbackFromSimulationStatus(const std_msgs::Bool::ConstPtr &msg)
+{
+  // Set the displacement threshold here for the simulator (which needs to be much tighter)
+  //   than the displacement threshold for the site at low speed testing.
+  if (msg->data){
+    displacement_threshold_ = 0.05;
+  }
+}
+
+double PurePursuit::getDisplacementThreshold() {
+  return displacement_threshold_;
+}
+
 double PurePursuit::getCmdVelocity(int waypoint) const
 {
   if (current_waypoints_.isEmpty())
@@ -306,6 +319,14 @@ void PurePursuit::getNextWaypoint()
   num_of_next_waypoint_ = -1;
   return;
 }
+
+/*
+styx_msgs::DisplacementThreshold PurePursuit::outputDisplacementThreshold() const {
+  styx_msgs::DisplacementThreshold disp;
+  disp.header.stamp = ros::Time::now();
+  twist.displacement = displacement_threshold_;
+}
+*/
 
 geometry_msgs::TwistStamped PurePursuit::outputZero() const
 {

--- a/ros/src/waypoint_loader/waypoint_loader.py
+++ b/ros/src/waypoint_loader/waypoint_loader.py
@@ -32,7 +32,7 @@ class WaypointLoader(object):
         if os.path.isfile(path):
             waypoints = self.load_waypoints(path)
             self.publish(waypoints)            
-            rospy.loginfo('Waypoint Loded')
+            rospy.loginfo('Waypoint Loaded')
         else:
             rospy.logerr('%s is not a file', path)
 


### PR DESCRIPTION
Added messaging to allow variable displacement thresholds for the
simulator and site test environments to prevent overcorrection of
steering for small deviations in position in the site, while
mitigating wander at low speed simulation testing.